### PR TITLE
Auflösung nun während des Spiels änderbar

### DIFF
--- a/MonoGameUi/BaseScreenComponent.cs
+++ b/MonoGameUi/BaseScreenComponent.cs
@@ -80,6 +80,16 @@ namespace MonoGameUi
                     root.InternalKeyTextPress(args);
                 }
             };
+
+            Game.Window.ClientSizeChanged += (s, e) =>
+            {
+                ClientSizeChanged?.Invoke(s, e);
+            };
+
+
+
+
+
         }
 
         protected override void LoadContent()
@@ -589,5 +599,7 @@ namespace MonoGameUi
         public event KeyEventBaseDelegate KeyDown;
         public event KeyEventBaseDelegate KeyPress;
         public event KeyEventBaseDelegate KeyUp;
+
+        public event EventHandler ClientSizeChanged;
     }
 }

--- a/MonoGameUi/Control.cs
+++ b/MonoGameUi/Control.cs
@@ -185,7 +185,7 @@ namespace MonoGameUi
 
             manager.ClientSizeChanged += (s, e) =>
             {
-                InvalidateDimensions();
+                OnResolutionChanged();
             };
 
             ApplySkin(typeof(Control));
@@ -1016,6 +1016,11 @@ namespace MonoGameUi
         {
             invalidDimensions = true;
             InvalidateDrawing();
+        }
+
+        public void OnResolutionChanged()
+        {
+            InvalidateDimensions();
         }
 
         /// <summary>

--- a/MonoGameUi/Control.cs
+++ b/MonoGameUi/Control.cs
@@ -183,6 +183,11 @@ namespace MonoGameUi
             children.OnInsert += ControlCollectionInsert;
             children.OnRemove += ControlCollectionRemove;
 
+            manager.ClientSizeChanged += (s, e) =>
+            {
+                InvalidateDimensions();
+            };
+
             ApplySkin(typeof(Control));
         }
 

--- a/MonoGameUi/IScreenManager.cs
+++ b/MonoGameUi/IScreenManager.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using System;
 using System.Collections.Generic;
 
 namespace MonoGameUi
@@ -94,6 +95,8 @@ namespace MonoGameUi
         event KeyEventBaseDelegate KeyDown;
         event KeyEventBaseDelegate KeyPress;
         event KeyEventBaseDelegate KeyUp;
+
+        event EventHandler ClientSizeChanged;
     }
 
     /// <summary>

--- a/SampleClient/SampleGame.cs
+++ b/SampleClient/SampleGame.cs
@@ -41,8 +41,26 @@ namespace SampleClient
                 Console.WriteLine("Up: " + args.Key.ToString());
             };
 
+            
+
 
             base.Initialize();
+        }
+
+        protected override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+            KeyboardState state = Keyboard.GetState();
+            if(state.IsKeyDown(Keys.F11))
+            {
+                graphics.ToggleFullScreen();
+            }
+            if(state.IsKeyDown(Keys.F12))
+            {
+                graphics.PreferredBackBufferWidth = 1920;
+                graphics.PreferredBackBufferHeight = 1080;
+                graphics.ApplyChanges();
+            }
         }
     }
 }


### PR DESCRIPTION
Hab das mal als Pull-Request reingestellt weil meine Lösung vielleicht nicht die sauberste ist.

Grundsätzlich ist es nun möglich die Auflösung im laufenden Spiel zu ändern.
Dazu gibt es im IScreenManager nun ein Event (ClientSizeChanged), welches in das in Game.Window vorhandene Event hakt, und aufgerufen wird sobald sich die Auflösung ändert.

In der Control Klasse gibt es außerdem eine Methode "OnResolutionChanged" welche einfach InvalidateDimensions() aufruft... Sie kann bei Bedarf überschrieben werden...
