### PR TITLE
Disabled state brush

### DIFF
--- a/MonoGameUi/Control.cs
+++ b/MonoGameUi/Control.cs
@@ -296,6 +296,9 @@ namespace MonoGameUi
             // Fokus-Frame
             if (Focused == TreeState.Active)
                 OnDrawFocusFrame(batch, controlWithMargin, gameTime, AbsoluteAlpha);
+
+            if (!Enabled)
+                OnDrawDisabled(batch, controlWithMargin, gameTime, AbsoluteAlpha);
         }
 
         /// <summary>
@@ -308,9 +311,9 @@ namespace MonoGameUi
         protected virtual void OnDrawBackground(SpriteBatch batch, Rectangle backgroundArea, GameTime gameTime, float alpha)
         {
             // Standard Background zeichnen
-            if (Pressed && PressedBackground != null)
+            if (Pressed && PressedBackground != null && Enabled)
                 PressedBackground.Draw(batch, backgroundArea, alpha);
-            else if (Hovered != TreeState.None && HoveredBackground != null)
+            else if (Hovered != TreeState.None && HoveredBackground != null && Enabled)
                 HoveredBackground.Draw(batch, backgroundArea, alpha);
             else if (Background != null)
                 Background.Draw(batch, backgroundArea, alpha);
@@ -338,6 +341,19 @@ namespace MonoGameUi
         {
             if (Skin.Current.FocusFrameBrush != null)
                 Skin.Current.FocusFrameBrush.Draw(batch, contentArea, AbsoluteAlpha);
+        }
+
+        /// <summary>
+        /// Malt den deaktivierten Zustand des Controls
+        /// </summary>
+        /// <param name="batch">Spritebatch</param>
+        /// <param name="contentArea">Bereich für den Content in absoluten Koordinaten</param>
+        /// <param name="gameTime">GameTime</param>
+        /// <param name="alpha">Die Transparenz des Controls.</param>
+        protected virtual void OnDrawDisabled(SpriteBatch batch, Rectangle contentArea, GameTime gameTime, float alpha)
+        {
+            if (Skin.Current.DisabledBrush != null)
+                Skin.Current.DisabledBrush.Draw(batch, contentArea, alpha);
         }
 
         public void InvalidateDrawing()

--- a/MonoGameUi/Label.cs
+++ b/MonoGameUi/Label.cs
@@ -132,6 +132,13 @@ namespace MonoGameUi
             ApplySkin(typeof(Label));
         }
 
+        /// <summary>
+        /// Malt den Content des Controls
+        /// </summary>
+        /// <param name="batch">Spritebatch</param>
+        /// <param name="area">Bereich für den Content in absoluten Koordinaten</param>
+        /// <param name="gameTime">GameTime</param>
+        /// <param name="alpha">Die Transparenz des Controls.</param>
         protected override void OnDrawContent(SpriteBatch batch, Rectangle area, GameTime gameTime, float alpha)
         {
             // Rahmenbedingungen fürs Rendern checken
@@ -188,6 +195,22 @@ namespace MonoGameUi
             }
         }
 
+        /// <summary>
+        /// Malt den deaktivierten Zustand des Controls
+        /// </summary>
+        /// <param name="batch">Spritebatch</param>
+        /// <param name="contentArea">Bereich für den Content in absoluten Koordinaten</param>
+        /// <param name="gameTime">GameTime</param>
+        /// <param name="alpha">Die Transparenz des Controls.</param>
+        protected override void OnDrawDisabled(SpriteBatch batch, Rectangle contentArea, GameTime gameTime, float alpha)
+        {
+            // Kein weißer Hintergrund für Lables
+        }
+
+        /// <summary>
+        /// Ist für die Berechnung des Client-Contents zuständig und erleichtert das automatische Alignment.
+        /// </summary>
+        /// <returns></returns>
         public override Point CalculcateRequiredClientSpace(Point available)
         {
             if (Font == null) return Point.Zero;

--- a/MonoGameUi/Skin.cs
+++ b/MonoGameUi/Skin.cs
@@ -61,6 +61,8 @@ namespace MonoGameUi
 
             SelectedItemBrush = new BorderBrush(Color.Red);
 
+            DisabledBrush = new BorderBrush(Color.White * 0.4f);
+
             // =============
             // Skin-Methoden
             // =============
@@ -298,6 +300,11 @@ namespace MonoGameUi
         /// Standard-Brush für die Progress-Bar
         /// </summary>
         public Brush ProgressBarBrush { get; set; }
+
+        /// <summary>
+        /// Brush, die über deaktivierte Controls gemalt wird.
+        /// </summary>
+        public Brush DisabledBrush { get; set; }
 
         #endregion
 

--- a/SampleClient/CustomSkin.cs
+++ b/SampleClient/CustomSkin.cs
@@ -1,6 +1,7 @@
 ﻿using MonoGameUi;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Audio;
+using Microsoft.Xna.Framework;
 
 namespace SampleClient
 {
@@ -8,8 +9,8 @@ namespace SampleClient
     {
         public CustomSkin(ContentManager content) : base(content)
         {
-            SoundEffect click = content.Load<SoundEffect>("click1");
-            SoundEffect hover = content.Load<SoundEffect>("rollover5");
+            //SoundEffect click = content.Load<SoundEffect>("click1");
+            //SoundEffect hover = content.Load<SoundEffect>("rollover5");            
 
             StyleSkins.Add("special", (c) =>
             {
@@ -17,8 +18,8 @@ namespace SampleClient
                 {
                     c.Width = 200;
                     Button button = c as Button;
-                    button.ClickSound = click;
-                    button.HoverSound = hover;
+                    //button.ClickSound = click;
+                    //button.HoverSound = hover;
                 }
             });
         }

--- a/SampleClient/Screens/SplitScreen.cs
+++ b/SampleClient/Screens/SplitScreen.cs
@@ -136,14 +136,24 @@ namespace SampleClient.Screens
                 MinWidth = 100                                          //Eine Textbox kann ihre Größe automatisch anpassen
             };
 
-            Button clearTextbox = new Button(manager);
+            Button clearTextbox = Button.TextButton(manager, "Clear Textbox");
             clearTextbox.LeftMouseClick += (s, e) =>
             {
                 textbox.SelectionStart = 0;
                 textbox.Text = "";
             };
+
+            Button disableControls = Button.TextButton(manager, "Toggle Controls disabled");
+            disableControls.LeftMouseClick += (s, e) =>
+            {
+                foreach (var c in panel.Controls)
+                {
+                    c.Enabled = !c.Enabled;
+                }
+            };
             panel.Controls.Add(clearTextbox);
             panel.Controls.Add(textbox);                                //Textbox zu Panel hinzufügen
+            panel.Controls.Add(disableControls);
 
         }
 


### PR DESCRIPTION
Wenn das Control deaktiviert ist, sieht man das jetzt auch:
* Neue `DisabledBrush` im `Skin` mit einem Standardwert eines durchsichtigen weiß (`Color.White * 0.4f`)
* Eine neue `OnDrawDisabled`-Methode im Control, die über die ContentArea einfach die DisabledBrush malt
* Auch Hover/Pressed wird nicht gezeichnet, wenn das Control deaktiviert ist
* Zum Testen: Button zum Deaktivieren aller Controls im SampleClient

fixes #36 