### PR TITLE
Fix recursion bug in ControlCollection

### DIFF
--- a/MonoGameUi/ControlCollection.cs
+++ b/MonoGameUi/ControlCollection.cs
@@ -66,9 +66,9 @@ namespace MonoGameUi
             }
             base.Clear();
             InZOrder.Clear();
-            
+
             Owner.PathDirty = true;
-            
+
             ReorderZ(null);
         }
 
@@ -92,7 +92,7 @@ namespace MonoGameUi
             }
 
             InZOrder.Add(item);//TODO: insert sort?
-            
+
             // ZOrder einreihen
             item.ZOrderChanged += item_ZOrderChanged;
 
@@ -113,7 +113,7 @@ namespace MonoGameUi
                 item.SetFocus(null);
 
                 InZOrder.Remove(item);
-                
+
                 item.Parent = null;
                 item.ZOrderChanged -= item_ZOrderChanged;
 
@@ -157,7 +157,7 @@ namespace MonoGameUi
 
         void item_ZOrderChanged(Control sender, PropertyEventArgs<int> args)
         {
-            if (InZOrder == null) return;
+            if (InZOrder == null || isDoingUpdate) return;
 
             // Ein Control hat die Z-Order geändert -> neu sortieren
             ReorderZ(sender);
@@ -173,8 +173,10 @@ namespace MonoGameUi
             }
         }
         private readonly ZOrderComparer _zOrderComparer = new ZOrderComparer();
+        private bool isDoingUpdate = false;
         private void ReorderZ(Control control)
         {
+            isDoingUpdate = true;
             // Platz schaffen für das veränderte Control
             if (control != null)
                 foreach (var c in this)
@@ -189,6 +191,8 @@ namespace MonoGameUi
                 c.TabOrder = index++;
 
             AgainstZOrder.BaseList = InZOrder;
+
+            isDoingUpdate = false;
         }
     }
 }

--- a/MonoGameUi/ControlCollection.cs
+++ b/MonoGameUi/ControlCollection.cs
@@ -109,7 +109,6 @@ namespace MonoGameUi
         {
             if (base.Remove(item))
             {
-
                 item.SetFocus(null);
 
                 InZOrder.Remove(item);
@@ -156,12 +155,7 @@ namespace MonoGameUi
         }
 
         void item_ZOrderChanged(Control sender, PropertyEventArgs<int> args)
-        {
-            if (InZOrder == null || isDoingUpdate) return;
-
-            // Ein Control hat die Z-Order geändert -> neu sortieren
-            ReorderZ(sender);
-        }
+            => ReorderZ(sender); // Ein Control hat die Z-Order geändert -> neu sortieren
 
         private class ZOrderComparer : IComparer<Control>
         {
@@ -176,7 +170,10 @@ namespace MonoGameUi
         private bool isDoingUpdate = false;
         private void ReorderZ(Control control)
         {
+            if (isDoingUpdate) return; // Wir sind schon in einem Reorder-Vorgang
+
             isDoingUpdate = true;
+
             // Platz schaffen für das veränderte Control
             if (control != null)
                 foreach (var c in this)

--- a/MonoGameUi/MonoGameUi.csproj
+++ b/MonoGameUi/MonoGameUi.csproj
@@ -40,17 +40,24 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="engenious, Version=0.1.8.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\engenious.0.1.8\lib\net40\engenious.dll</HintPath>
+    <Reference Include="engenious">
+      <HintPath>..\packages\engenious.0.1.23\lib\net40\engenious.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NVorbis, Version=0.8.4.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\engenious.0.1.8\lib\net40\NVorbis.dll</HintPath>
+    <Reference Include="NVorbis">
+      <HintPath>..\packages\engenious.0.1.23\lib\net40\NVorbis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="OpenTK, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4">
-      <HintPath>..\packages\engenious.0.1.8\lib\net40\OpenTK.dll</HintPath>
+    <Reference Include="OpenTK">
+      <HintPath>..\packages\engenious.0.1.23\lib\net40\OpenTK.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Numerics.Vectors">
+      <HintPath>..\packages\engenious.0.1.23\lib\net40\System.Numerics.Vectors.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -109,13 +116,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\engenious.0.0.1.20\build\engenious.targets" Condition="Exists('..\packages\engenious.0.0.1.20\build\engenious.targets')" />
-  <Import Project="..\packages\engenious.0.1.8\build\engenious.targets" Condition="Exists('..\packages\engenious.0.1.8\build\engenious.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\engenious.0.1.8\build\engenious.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\engenious.0.1.8\build\engenious.targets'))" />
+    <Error Condition="!Exists('..\packages\engenious.0.1.23\build\engenious.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\engenious.0.1.23\build\engenious.targets'))" />
   </Target>
+  <Import Project="..\packages\engenious.0.1.23\build\engenious.targets" Condition="Exists('..\packages\engenious.0.1.23\build\engenious.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MonoGameUi/packages.config
+++ b/MonoGameUi/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="engenious" version="0.1.23" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
Aus OctoAwesome/octoawesome#250:

> Warum das hier so langsam läuft... Ein Schleifendurchlauf dauert 25s! Mal schnell durchprofilert: Liegt an MonoGameUI (`ControlCollection.Add`), was heftig CPU-Zeit verbrät. MonoGameUi wurde ja auch in deisem Pull Request upgedated, könnte es daran liegen?

> ![grafik](https://user-images.githubusercontent.com/10050780/37294911-3b44ce4e-2617-11e8-9b36-c3b2440aa4b2.png)
> Weiteres Profiling: CPU-Zeit wird fast 1:1 von `ControlCollection.ReorderZ` verbraten. Und hier wird es komisch: Vom profiling siehts fast so aus, als wäre die Methode rekursiv:
![grafik](https://user-images.githubusercontent.com/10050780/37295640-f89cb5fa-2618-11e8-8dd5-7de8910b35b6.png)

> Aber ich sehe jetzt auf den ersten Blick auch noch nicht, wo diese rekursivität her kommt: Vielleicht so: In ReorderZ wird der ZIndex der Controls geändert. Das feuert das ein  Event, wo der Handler item_ZOrderChanged registriert ist, der wiederum `ReorderZ` aufruft...

> Performance: Das MonoGameUI-Issue, das hat was mit deinem Changeset (speziell dem Update von MonoGameUi)  zu tun. Sonst kommen wir ja noch nicht mal dazu die Schatten zu sehen...  Ich habe aber eine starke Vermutung, woran es liegt, und einen einfachen (aber unsauberen...) Weg es zu lösen:

> ![grafik](https://user-images.githubusercontent.com/10050780/37301243-502b0f9c-2628-11e8-9452-348983c748cc.png)
>Hier der [MonoGameUi-Code *vor* dem Update.](https://github.com/OctoAwesome/monogameui/blob/56025fd848de0590749407b4381be91ffae728b8/MonoGameUi/ControlCollection.cs#L145-L160) Da InZOrder vor dem Sortieren auf null gesetzt wird, kommt es nie zur Rekursion (vgl. markierte Zeilen)

>In der jetzigen Version wird die Liste nicht mehr in der Methode gesetzt (auch nicht auf null). Daher kommt es zur Rekursion.

>Einfacher Quick&Dirty Fix wäre das Einfügen eines bools, der speichert, ob gerade neu sortiert wird...

Genau diesen Fix habe ich hier umgesetzt.
